### PR TITLE
update action .yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ inputs:
   glob_pattern:
     description: "Glob pattern of the files to lint"
     required: false
-    default: "."
+    default: "**/*.py"
   pylint_rc:
     description: "Path to the .pylintrc configuration file. pylint automatically searches for it if not provided."
     required: false


### PR DESCRIPTION
default value for glob-pattern should specify a file type  If one uses this action without giving glob-pattern explicitly as some file type then the GitHub actions fail because the default value is set as '.' which refers to the working directory and not the type of file on which it had to run.